### PR TITLE
Use Rust stable.

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable
         override: true
 
     - name: Install rustfmt


### PR DESCRIPTION
As of #5, Rust `nightly` is no longer needed. Use Rust `stable` for CI.