### PR TITLE
Add from_bytes_unchecked method to Opcode

### DIFF
--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -94,9 +94,17 @@ fn opcode() {
         bytes.extend(&buffer);
 
         let op_p = u32::from(op);
+        let mut op_bytes = op_p.to_be_bytes().to_vec();
+
         let op_p = Opcode::from(op_p);
+        let op_q = Opcode::from_bytes_unchecked(op_bytes.as_slice());
+
+        op_bytes.push(0xff);
+        let op_r = Opcode::from_bytes_unchecked(op_bytes.as_slice());
 
         assert_eq!(op, op_p);
+        assert_eq!(op, op_q);
+        assert_eq!(op, op_r);
     }
 
     let mut op_p = Opcode::Undefined;


### PR DESCRIPTION
Very often a opcode is created out of sized slices that are guaranteed
to contain the needed bytes.

This method will provide a fast way to perform conversion of bytes to
opcodes without additional overhead or code verbosity.