### PR TITLE
Change feature serde-types-default to serde-types

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --verbose --target thumbv6m-none-eabi --no-default-features --features serde-types
+        args: --verbose --target thumbv6m-none-eabi --no-default-features --features serde-types-minimal
 
     - name: Run tests
       uses: actions-rs/cargo@v1
@@ -80,10 +80,10 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --features serde-types-default
+        args: --verbose --features serde-types
 
     - name: Run serde tests no-std
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --no-default-features --features serde-types
+        args: --verbose --no-default-features --features serde-types-minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 [features]
 default = ["std"]
 std = []
-serde-types-default = [ "serde/default", "std" ]
-serde-types = [ "serde" ]
+serde-types = [ "serde-types-minimal", "serde/default", "std" ]
+serde-types-minimal = [ "serde" ]
+
+[[test]]
+name = "test-encoding"
+path = "tests/encoding.rs"
+required-features = ["std"]

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -10,7 +10,7 @@ pub mod consts;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
-    any(feature = "serde-types", feature = "serde-types-default"),
+    feature = "serde-types-minimal",
     derive(serde::Serialize, serde::Deserialize)
 )]
 /// Instruction representation for the interpreter.

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -1,5 +1,4 @@
 #[test]
-#[cfg(feature = "std")]
 fn opcode() {
     use fuel_asm::*;
     use std::io::{Read, Write};


### PR DESCRIPTION
Creating a new feature will cause an unnecessary breaking change

The new std/no-std scheme can trivially be used with a different feature
set that will be an extension of the previous one