### PR TITLE
Add `fuel-types` as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 categories = ["cryptography::cryptocurrencies", "data-structures", "parsing"]
 
 [dependencies]
-fuel-data = { git = "ssh://git@github.com/FuelLabs/fuel-data.git", default-features = false }
+fuel-types = { git = "ssh://git@github.com/FuelLabs/fuel-types.git", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [features]
-default = [ "fuel-data/default", "std" ]
-std = [ "fuel-data/std" ]
-serde-types = [ "fuel-data/serde-types", "serde-types-minimal", "serde/default", "std" ]
-serde-types-minimal = [ "fuel-data/serde-types-minimal", "serde" ]
+default = [ "fuel-types/default", "std" ]
+std = [ "fuel-types/std" ]
+serde-types = [ "fuel-types/serde-types", "serde-types-minimal", "serde/default", "std" ]
+serde-types-minimal = [ "fuel-types/serde-types-minimal", "serde" ]
 
 [[test]]
 name = "test-encoding"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@
 
 mod opcode;
 
-pub use fuel_data::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId, Word};
+pub use fuel_types::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId, Word};
 pub use opcode::Opcode;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,4 +1,4 @@
-use fuel_data::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId};
+use fuel_types::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId};
 
 use core::convert::TryFrom;
 


### PR DESCRIPTION
The types previously defined in `fuel-data` were migrated to
`fuel-types` to split the VM/infrastructure requirements with the
general data traits