### PR TITLE
Add MCPI Opcode

### DIFF
--- a/src/opcode/consts.rs
+++ b/src/opcode/consts.rs
@@ -201,8 +201,8 @@ pub enum OpcodeRepr {
     SB = 0x5e,
     /// SW
     SW = 0x5f,
-    /// RESERV60
-    RESERV60 = 0x60,
+    /// MCPI
+    MCPI = 0x60,
     /// RESERV61
     RESERV61 = 0x61,
     /// RESERV62

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -9,7 +9,7 @@ fn opcode() {
     let imm18 = 0x2ffff;
     let imm24 = 0xbfffff;
 
-    let data = vec![
+    let mut data = vec![
         Opcode::ADD(r, r, r),
         Opcode::ADDI(r, r, imm12),
         Opcode::AND(r, r, r),
@@ -53,6 +53,7 @@ fn opcode() {
         Opcode::MCL(r, r),
         Opcode::MCLI(r, imm18),
         Opcode::MCP(r, r, r),
+        Opcode::MCPI(r, r, imm12),
         Opcode::MEQ(r, r, r, r),
         Opcode::SB(r, r, imm12),
         Opcode::SW(r, r, imm12),
@@ -89,8 +90,12 @@ fn opcode() {
         Opcode::FLAG(r),
         Opcode::GM(r, imm18),
         Opcode::Undefined,
-        Opcode::Undefined,
     ];
+
+    // Pad to even length
+    if data.len() % 2 != 0 {
+        data.push(Opcode::Undefined);
+    }
 
     let bytes: Vec<u8> = data.iter().copied().collect();
 


### PR DESCRIPTION
Closes Issue #21 

- Added the opcode for MCPI including tests
- Added a note to reserve opcodes `0xb0..0xef` as temporary opcodes to be finalized before we go to prod, in order to prevent breakage while opcodes are still being implemented.

## Tests results

```
❯ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests (target/debug/deps/fuel_asm-07eac6040bb809d5)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/encoding.rs (target/debug/deps/test_encoding-24265e0f65e4e21b)

running 1 test
test opcode ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests fuel-asm

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```