### PR TITLE
Impl `Hash` for `Instruction`

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -6,7 +6,7 @@ use fuel_types::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId,
 use std::{io, iter};
 
 /// A version of Opcode that can used without unnecessary branching
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde-types-minimal",
     derive(serde::Serialize, serde::Deserialize)


### PR DESCRIPTION
`Instruction` sould reflect the same implementations as `Opcode`. The
former doesn't implement `Hash`, while the latter does.

`Hash` is mandatory if the structure is to be used with map-like
implementations. That way, having that implementation for `Instruction`
is desirable.