### PR TITLE
Implement `Error` for `PanicReason`

### DIFF
--- a/src/panic_reason.rs
+++ b/src/panic_reason.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde-types-minimal",
@@ -518,4 +520,17 @@ pub enum PanicReason {
     RESERVFE = 0xfe,
     /// RESERVFF
     RESERVFF = 0xff,
+}
+
+impl fmt::Display for PanicReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PanicReason {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
 }


### PR DESCRIPTION
The interpreter will use `PanicReason` as error for instructions
execution.

That way, the default traits must be implemented for the type.