### PR TITLE
Add `From<Infallible>` impl for `PanicReason`

### DIFF
--- a/src/panic_reason.rs
+++ b/src/panic_reason.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::{convert, fmt};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
@@ -532,5 +532,11 @@ impl fmt::Display for PanicReason {
 impl std::error::Error for PanicReason {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
+    }
+}
+
+impl From<convert::Infallible> for PanicReason {
+    fn from(_i: convert::Infallible) -> Self {
+        unreachable!()
     }
 }


### PR DESCRIPTION
Some implementations in the interpreter benefir from the standard lib
`Infallible` implementation for errors that won't ever happen, except
for critical OS failures that are beyond the runtime control scope.

PanicReason should derive an implementation of infallible, and panic in
case it is ever reached.