### PR TITLE
Remove long docs for opcodes.

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -44,1247 +44,247 @@ pub use consts::OpcodeRepr;
 /// their operation.
 pub enum Opcode {
     /// Adds two registers.
-    ///
-    /// | Operation   | ```$rA = $rB + $rC;``` |
-    /// | Syntax      | `add $rA, $rB, $rC`    |
-    /// | Encoding    | `0x00 rA rB rC -`      |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    /// `$err` is cleared.
     ADD(RegisterId, RegisterId, RegisterId),
 
     /// Adds a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB + imm;```                  |
-    /// | Syntax      | `addi $rA, $rB, immediate`              |
-    /// | Encoding    | `0x00 rA rB i i`                        |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    /// `$err` is cleared.
     ADDI(RegisterId, RegisterId, Immediate12),
 
     /// Bitwise ANDs two registers.
-    ///
-    /// | Operation   | ```$rA = $rB & $rC;```      |
-    /// | Syntax      | `and $rA, $rB, $rC`         |
-    /// | Encoding    | `0x00 rA rB rC -`           |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     AND(RegisterId, RegisterId, RegisterId),
 
     /// Bitwise ANDs a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB & imm;```                          |
-    /// | Syntax      | `andi $rA, $rB, imm`                            |
-    /// | Encoding    | `0x00 rA rB i i`                                |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// `imm` is extended to 64 bits, with the high 52 bits set to `0`.
-    /// `$of` and `$err` are cleared.
     ANDI(RegisterId, RegisterId, Immediate12),
 
     /// Divides two registers.
-    ///
-    /// | Operation   | ```$rA = $rB // $rC;``` |
-    /// | Syntax      | `div $rA, $rB, $rC`     |
-    /// | Encoding    | `0x00 rA rB rC -`       |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// If `$rC == 0`, `$rA` is cleared and `$err` is set to `true`.
-    /// Otherwise, `$err` is cleared.
-    /// `$of` is cleared.
     DIV(RegisterId, RegisterId, RegisterId),
 
     /// Divides a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB // imm;```                    |
-    /// | Syntax      | `divi $rA, $rB, imm`                       |
-    /// | Encoding    | `0x00 rA rB i i`                           |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register.
-    ///
-    /// #### Execution
-    /// If `imm == 0`, `$rA` is cleared and `$err` is set to `true`.
-    /// Otherwise, `$err` is cleared.
-    /// `$of` is cleared.
     DIVI(RegisterId, RegisterId, Immediate12),
 
     /// Compares two registers for equality.
-    ///
-    /// | Operation   | ```$rA = $rB == $rC;```              |
-    /// | Syntax      | `eq $rA, $rB, $rC`                   |
-    /// | Encoding    | `0x00 rA rB rC -`                    |
-    ///
-    /// #### Panics
-    /// - `$rA` is a reserved register,
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     EQ(RegisterId, RegisterId, RegisterId),
 
     /// Raises one register to the power of another.
-    ///
-    /// | Operation   | ```$rA = $rB ** $rC;```                      |
-    /// | Syntax      | `exp $rA, $rB, $rC`                          |
-    /// | Encoding    | `0x00 rA rB rC -`                            |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise
-    /// `$of` is cleared.
-    /// `$err` is cleared.
     EXP(RegisterId, RegisterId, RegisterId),
 
     /// Raises one register to the power of an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB ** imm;```             |
-    /// | Syntax      | `expi $rA, $rB, imm`                |
-    /// | Encoding    | `0x00 rA rB i i`                    |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If the result cannot fit in 8 bytes, `$of` is set to `1`, otherwise
-    /// `$of` is cleared.
-    /// `$err` is cleared.
     EXPI(RegisterId, RegisterId, Immediate12),
 
     /// Compares two registers for greater-than.
-    ///
-    /// | Operation   | ```$rA = $rB > $rC;```                   |
-    /// | Syntax      | `gt $rA, $rB, $rC`                       |
-    /// | Encoding    | `0x00 rA rB rC -`                        |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     GT(RegisterId, RegisterId, RegisterId),
 
     /// Compares two registers for less-than.
-    ///
-    /// | Operation   | ```$rA = $rB < $rC;```                |
-    /// | Syntax      | `lt $rA, $rB, $rC`                    |
-    /// | Encoding    | `0x00 rA rB rC -`                     |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     LT(RegisterId, RegisterId, RegisterId),
 
-    /// The (integer) logarithm base `$rC` of `$rB`.
-    ///
-    /// | Operation   | ```$rA = math.floor(math.log($rB, $rC));```  |
-    /// | Syntax      | `mlog $rA, $rB, $rC`                         |
-    /// | Encoding    | `0x00 rA rB rC -`                            |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If `$rB == 0`, both `$rA` and `$of` are cleared and `$err` is set to
-    /// `true`.
-    ///
-    /// If `$rC <= 1`, both `$rA` and `$of` are cleared and `$err` is set to
-    /// `true`.
-    ///
-    /// Otherwise, `$of` and `$err` are cleared.
+    /// The integer logarithm of a register.
     MLOG(RegisterId, RegisterId, RegisterId),
 
-    /// The (integer) `$rC`th root of `$rB`.
-    ///
-    /// | Operation   | ```$rA = math.floor(math.root($rB, $rC));``` |
-    /// | Syntax      | `mroo $rA, $rB, $rC`                         |
-    /// | Encoding    | `0x00 rA rB rC -`                            |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If `$rC == 0`, both `$rA` and `$of` are cleared and `$err` is set to
-    /// `true`.
-    ///
-    /// Otherwise, `$of` and `$err` are cleared.
+    /// The integer root of a register.
     MROO(RegisterId, RegisterId, RegisterId),
 
     /// Modulo remainder of two registers.
-    ///
-    /// | Operation   | ```$rA = $rB % $rC;```             |
-    /// | Syntax      | `mod $rA, $rB, $rC`                |
-    /// | Encoding    | `0x00 rA rB rC -`                  |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If `$rC == 0`, both `$rA` and `$of` are cleared and `$err` is set to
-    /// `true`.
-    ///
-    /// Otherwise, `$of` and `$err` are cleared.
     MOD(RegisterId, RegisterId, RegisterId),
 
     /// Modulo remainder of a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB % imm;```                                 |
-    /// | Syntax      | `modi $rA, $rB, imm`                                   |
-    /// | Encoding    | `0x00 rA rB i i`                                       |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// If `imm == 0`, both `$rA` and `$of` are cleared and `$err` is set to
-    /// `true`.
-    ///
-    /// Otherwise, `$of` and `$err` are cleared.
     MODI(RegisterId, RegisterId, Immediate12),
 
     /// Copy from one register to another.
-    ///
-    /// | Operation   | ```$rA = $rB;```                   |
-    /// | Syntax      | `move $rA, $rB`                    |
-    /// | Encoding    | `0x00 rA rB - -`                   |
-    /// | Notes       |                                    |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     MOVE(RegisterId, RegisterId),
 
     /// Multiplies two registers.
-    ///
-    /// | Operation   | ```$rA = $rB * $rC;```    |
-    /// | Syntax      | `mul $rA, $rB, $rC`       |
-    /// | Encoding    | `0x00 rA rB rC -`         |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    ///
-    /// `$err` is cleared.
     MUL(RegisterId, RegisterId, RegisterId),
 
     /// Multiplies a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB * imm;```                        |
-    /// | Syntax      | `mul $rA, $rB, imm`                           |
-    /// | Encoding    | `0x00 rA rB i i`                              |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    ///
-    /// `$err` is cleared.
     MULI(RegisterId, RegisterId, Immediate12),
 
     /// Bitwise NOT a register.
-    ///
-    /// | Operation   | ```$rA = ~$rB;```       |
-    /// | Syntax      | `not $rA, $rB`          |
-    /// | Encoding    | `0x00 rA rB - -`        |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     NOT(RegisterId, RegisterId),
 
     /// Bitwise ORs two registers.
-    ///
-    /// | Operation   | ```$rA = $rB \| $rC;```    |
-    /// | Syntax      | `or $rA, $rB, $rC`         |
-    /// | Encoding    | `0x00 rA rB rC -`          |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     OR(RegisterId, RegisterId, RegisterId),
 
     /// Bitwise ORs a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB \| imm;```                        |
-    /// | Syntax      | `ori $rA, $rB, imm`                            |
-    /// | Encoding    | `0x00 rA rB i i`                               |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `imm` is extended to 64 bits, with the high 52 bits set to `0`.
-    ///
-    /// `$of` and `$err` are cleared.
     ORI(RegisterId, RegisterId, Immediate12),
 
     /// Left shifts a register by a register.
-    ///
-    /// | Operation   | ```$rA = $rB << $rC;```               |
-    /// | Syntax      | `sll $rA, $rB, $rC`                   |
-    /// | Encoding    | `0x00 rA rB rC -`                     |
-    /// | Notes       | Zeroes are shifted in.                |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    ///
-    /// `$err` is cleared.
     SLL(RegisterId, RegisterId, RegisterId),
 
     /// Left shifts a register by an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB << imm;```                       |
-    /// | Syntax      | `slli $rA, $rB, imm`                          |
-    /// | Encoding    | `0x00 rA rB i i`                              |
-    /// | Notes       | Zeroes are shifted in.                        |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the overflow of the operation.
-    ///
-    /// `$err` is cleared.
     SLLI(RegisterId, RegisterId, Immediate12),
 
     /// Right shifts a register by a register.
-    ///
-    /// | Operation   | ```$rA = $rB >> $rC;```                |
-    /// | Syntax      | `srl $rA, $rB, $rC`                    |
-    /// | Encoding    | `0x00 rA rB rC -`                      |
-    /// | Notes       | Zeroes are shifted in.                 |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the underflow of the operation, as though `$of` is the
-    /// high byte of a 128-bit register.
-    ///
-    /// `$err` is cleared.
     SRL(RegisterId, RegisterId, RegisterId),
 
     /// Right shifts a register by an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB >> imm;```                        |
-    /// | Syntax      | `srli $rA, $rB, imm`                           |
-    /// | Encoding    | `0x00 rA rB i i`                               |
-    /// | Notes       | Zeroes are shifted in.                         |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the underflow of the operation, as though `$of` is the
-    /// high byte of a 128-bit register.
-    ///
-    /// `$err` is cleared.
     SRLI(RegisterId, RegisterId, Immediate12),
 
     /// Subtracts two registers.
-    ///
-    /// | Operation   | ```$rA = $rB - $rC;```                           |
-    /// | Syntax      | `sub $rA, $rB, $rC`                              |
-    /// | Encoding    | `0x00 rA rB rC -`                                |
-    /// | Notes       | `$of` is assigned the overflow of the operation. |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the underflow of the operation, as though `$of` is the
-    /// high byte of a 128-bit register.
-    ///
-    /// `$err` is cleared.
     SUB(RegisterId, RegisterId, RegisterId),
 
     /// Subtracts a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB - imm;```                           |
-    /// | Syntax      | `subi $rA, $rB, imm`                             |
-    /// | Encoding    | `0x00 rA rB i i`                                 |
-    /// | Notes       | `$of` is assigned the overflow of the operation. |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` is assigned the underflow of the operation, as though `$of` is the
-    /// high byte of a 128-bit register.
-    ///
-    /// `$err` is cleared.
     SUBI(RegisterId, RegisterId, Immediate12),
 
     /// Bitwise XORs two registers.
-    ///
-    /// | Operation   | ```$rA = $rB ^ $rC;```      |
-    /// | Syntax      | `xor $rA, $rB, $rC`         |
-    /// | Encoding    | `0x00 rA rB rC -`           |
-    /// | Notes       |                             |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     XOR(RegisterId, RegisterId, RegisterId),
 
     /// Bitwise XORs a register and an immediate value.
-    ///
-    /// | Operation   | ```$rA = $rB ^ imm;```                          |
-    /// | Syntax      | `xori $rA, $rB, imm`                            |
-    /// | Encoding    | `0x00 rA rB i i`                                |
-    /// | Notes       |                                                 |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    ///
-    /// #### Execution
-    /// `$of` and `$err` are cleared.
     XORI(RegisterId, RegisterId, Immediate12),
 
-    /// Set `$rA` to `true` if the `$rC <= tx.input[$rB].maturity`.
-    ///
-    /// | Operation   | ```$rA = checkinputmaturityverify($rB, $rC);``` |
-    /// | Syntax      | `cimv $rA $rB $rC`                              |
-    /// | Encoding    | `0x00 rA rB rC -`                               |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rC > tx.input[$rB].maturity`
-    /// - the input `$rB` is not of type
-    ///   [`InputType.Coin`](../protocol/tx_format.md)
-    /// - `$rB > tx.inputsCount`
-    ///
-    /// #### Execution
-    /// Otherwise, advance the program counter `$pc` by `4`.
-    ///
-    /// See also: [BIP-112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki) and [CLTV](#cltv-check-lock-time-verify).
+    /// Check relative timelock.
     CIMV(RegisterId, RegisterId, RegisterId),
 
-    /// Set `$rA` to `true` if `$rB <= tx.maturity`.
-    ///
-    /// | Operation   | ```$rA = checktransactionmaturityverify($rB);``` |
-    /// | Syntax      | `ctmv $rA $rB`                                   |
-    /// | Encoding    | `0x00 rA rB - -`                                 |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB > tx.maturity`
-    ///
-    /// #### Execution
-    /// Otherwise, advance the program counter `$pc` by `4`.
-    ///
-    /// See also: [BIP-65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki) and [Bitcoin's Time Locks](https://prestwi.ch/bitcoin-time-locks).
+    /// Check absolute timelock.
     CTMV(RegisterId, RegisterId),
 
-    /// Jumps to the code instruction offset by `imm`.
-    ///
-    /// | Operation   | ```$pc = $is + imm * 4;```                     |
-    /// | Syntax      | `ji imm`                                       |
-    /// | Encoding    | `0x00 i i i i`                                 |
-    ///
-    /// #### Panics
-    /// - `$is + imm * 4 > VM_MAX_RAM - 1`
+    /// Jump.
     JI(Immediate24),
 
-    /// Jump to the code instruction offset by `imm` if `$rA` is not equal to
-    /// `$rB`.
-    ///
-    /// | Operation   | ```if $rA != $rB:```<br>```$pc = $is + imm *
-    /// 4;```<br>```else:```<br>```$pc += 4;``` | Syntax      | `jnei $rA
-    /// $rB imm` | Encoding    | `0x00 rA rB i i`
-    ///
-    /// #### Panics
-    /// - `$is + imm * 4 > VM_MAX_RAM - 1`
+    /// Conditional jump.
     JNEI(RegisterId, RegisterId, Immediate12),
 
-    /// Returns from [context](./main.md#contexts) with value `$rA`.
-    ///
-    /// | Operation   | ```return($rA);```
-    /// | Syntax      | `ret $rA`
-    /// | Encoding    | `0x00 rA - - -`
-    ///
-    /// If current context is external, cease VM execution and return `$rA`.
-    ///
-    /// Returns from contract call, popping the call frame. Before popping:
-    ///
-    /// 1. Return the unused forwarded gas to the caller:
-    ///     - `$cgas = $cgas + $fp->$cgas` (add remaining context gas from
-    ///       previous context to current remaining context gas)
-    ///
-    /// Then pop the call frame and restoring registers _except_ `$ggas` and
-    /// `$cgas`. Afterwards, set the following registers:
-    ///
-    /// 1. `$pc = $pc + 4` (advance program counter from where we called)
+    /// Return from context.
     RET(RegisterId),
 
-    /// Return from context with data
-    ///
-    /// | Operation   | ```returndata($rA, $rB);```
-    /// | Syntax      | `retd $rA, $rB`
-    /// | Encoding    | `0x00 rA rB - -`
-    ///
-    /// If current context is external, cease VM execution and return `MEM[$rA, $rB]`.
-    ///
-    /// Returns from contract call, popping the call frame. Before popping:
-    ///
-    /// 1. Return the unused forwarded gas to the caller:
-    ///     - `$cgas = $cgas + $fp->$cgas` (add remaining context gas from
-    ///       previous context to current remaining context gas)
-    ///
-    /// Then pop the call frame and restoring registers _except_ `$ggas` and
-    /// `$cgas`. Afterwards, set the following registers:
-    ///
-    /// Set the return value:
-    ///
-    /// 1. `$ret = $rA`
-    /// 1. `$retl = $rB`
-    ///
-    /// 1. `$pc = $pc + 4` (advance program counter from where we called)
+    /// Return from context with data.
     RETD(RegisterId, RegisterId),
 
     /// Extend the current call frame's stack by an immediate value.
-    ///
-    /// | Operation   | ```$sp = $sp + imm```
-    /// | Syntax      | `cfei imm`
-    /// | Encoding    | `0x00 i i i i`
-    /// | Notes       | Does not initialize memory.
-    ///
-    /// #### Panics
-    /// - `$sp + imm` overflows
-    /// - `$sp + imm > $hp`
     CFEI(Immediate24),
 
     /// Shrink the current call frame's stack by an immediate value.
-    ///
-    /// | Operation   | ```$sp = $sp - imm```
-    /// | Syntax      | `cfsi imm`
-    /// | Encoding    | `0x00 i i i i`
-    /// | Notes       | Does not clear memory.
-    ///
-    /// #### Panics
-    /// - `$sp - imm` underflows
-    /// - `$sp - imm < $ssp`
     CFSI(Immediate24),
 
-    /// A byte is loaded from the specified address offset by `imm`.
-    ///
-    /// | Operation   | ```$rA = MEM[$rB + imm, 1];```
-    /// | Syntax      | `lb $rA, $rB, imm`
-    /// | Encoding    | `0x00 rA rB i i`
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + imm + 1` overflows
-    /// - `$rB + imm + 1 > VM_MAX_RAM`
+    /// A byte is loaded from the specified address offset by an immediate value.
     LB(RegisterId, RegisterId, Immediate12),
 
-    /// A word is loaded from the specified address offset by `imm`.
-    /// | Operation   | ```$rA = MEM[$rB + imm, 8];```
-    /// | Syntax      | `lw $rA, $rB, imm`
-    /// | Encoding    | `0x00 rA rB i i`
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + imm + 8` overflows
-    /// - `$rB + imm + 8 > VM_MAX_RAM`
+    /// A word is loaded from the specified address offset by an immediate value.
     LW(RegisterId, RegisterId, Immediate12),
 
     /// Allocate a number of bytes from the heap.
-    ///
-    /// | Operation   | ```$hp = $hp - $rA;```                    |
-    /// | Syntax      | `aloc $rA`                                |
-    /// | Encoding    | `0x00 rA - - -`                           |
-    /// | Notes       | Does not initialize memory.               |
-    ///
-    /// #### Panics
-    /// - `$hp - $rA` underflows
-    /// - `$hp - $rA < $sp`
     ALOC(RegisterId),
 
-    /// Clear bytes in memory.
-    ///
-    /// | Operation   | ```MEM[$rA, $rB] = 0;``` |
-    /// | Syntax      | `mcl $rA, $rB`           |
-    /// | Encoding    | `0x00 rA rB - -`         |
-    ///
-    /// #### Panics
-    /// - `$rA + $rB` overflows
-    /// - `$rA + $rB > VM_MAX_RAM`
-    /// - `$rB > MEM_MAX_ACCESS_SIZE`
-    /// - The memory range `MEM[$rA, $rB]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Clear a variable number of bytes in memory.
     MCL(RegisterId, RegisterId),
 
-    /// Clear bytes in memory.
-    ///
-    /// | Operation   | ```MEM[$rA, imm] = 0;``` |
-    /// | Syntax      | `mcli $rA, imm`          |
-    /// | Encoding    | `0x00 rA i i i`          |
-    ///
-    /// #### Panics
-    /// - `$rA + imm` overflows
-    /// - `$rA + imm > VM_MAX_RAM`
-    /// - `imm > MEM_MAX_ACCESS_SIZE`
-    /// - The memory range `MEM[$rA, imm]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Clear an immediate number of bytes in memory.
     MCLI(RegisterId, Immediate18),
 
-    /// Copy bytes in memory.
-    ///
-    /// | Operation   | ```MEM[$rA, $rC] = MEM[$rB, $rC];``` |
-    /// | Syntax      | `mcp $rA, $rB, $rC`                  |
-    /// | Encoding    | `0x00 rA rB rC -`                    |
-    ///
-    /// #### Panics
-    /// - `$rA + $rC` overflows
-    /// - `$rB + $rC` overflows
-    /// - `$rA + $rC > VM_MAX_RAM`
-    /// - `$rB + $rC > VM_MAX_RAM`
-    /// - `$rC > MEM_MAX_ACCESS_SIZE`
-    /// - The memory ranges `MEM[$rA, $rC]` and `MEM[$rB, $rC]` overlap
-    /// - The memory range `MEM[$rA, $rC]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Copy a variable number of bytes in memory.
     MCP(RegisterId, RegisterId, RegisterId),
 
-    /// Copy bytes in memory.
-    ///
-    /// | Operation   | ```MEM[$rA, imm] = MEM[$rB, imm];``` |
-    /// | Syntax      | `mcpi $rA, $rB, imm`                 |
-    /// | Encoding    | `0x00 rA rB i i`                     |
-    ///
-    /// #### Panics
-    ///
-    /// - `$rA + imm` overflows
-    /// - `$rB + imm` overflows
-    /// - `$rA + imm > VM_MAX_RAM`
-    /// - `$rB + imm > VM_MAX_RAM`
-    /// - `imm > MEM_MAX_ACCESS_SIZE`
-    /// - The memory ranges `MEM[$rA, imm]` and `MEM[$rB, imm]` overlap
-    /// - The memory range `MEM[$rA, imm]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Copy an immediate number of bytes in memory.
     MCPI(RegisterId, RegisterId, Immediate12),
 
     /// Compare bytes in memory.
-    ///
-    /// | Operation   | ```$rA = MEM[$rB, $rD] == MEM[$rC, $rD];``` |
-    /// | Syntax      | `meq $rA, $rB, $rC, $rD`                    |
-    /// | Encoding    | `0x00 rA rB rC rD`                          |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + $rD` overflows
-    /// - `$rC + $rD` overflows
-    /// - `$rB + $rD > VM_MAX_RAM`
-    /// - `$rC + $rD > VM_MAX_RAM`
-    /// - `$rD > MEM_MAX_ACCESS_SIZE`
     MEQ(RegisterId, RegisterId, RegisterId, RegisterId),
 
-    /// The least significant byte of `$rB` is stored at the address `$rA`
-    /// offset by `imm`.
-    ///
-    /// | Operation   | ```MEM[$rA + imm, 1] = $rB[7, 1];```    |
-    /// | Syntax      | `sb $rA, $rB, imm`                      |
-    /// | Encoding    | `0x00 rA rB i i`                        |
-    ///
-    /// #### Panics
-    /// - `$rA + imm + 1` overflows
-    /// - `$rA + imm + 1 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA + imm, 1]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Write the least significant byte of a register to memory.
     SB(RegisterId, RegisterId, Immediate12),
 
-    /// The value of `$rB` is stored at the address `$rA` offset by `imm`.
-    ///
-    /// | Operation   | ```MEM[$rA + imm, 8] = $rB;```
-    /// | Syntax      | `sw $rA, $rB, imm`
-    /// | Encoding    | `0x00 rA rB i i`
-    ///
-    /// #### Panics
-    /// - `$rA + imm + 8` overflows
-    /// - `$rA + imm + 8 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA + imm, 8]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Write a register to memory.
     SW(RegisterId, RegisterId, Immediate12),
 
-    /// Set `$rA` to the balance of color at `$rB` for contract with ID at
-    /// `$rC`. Where helper
-    /// `balance(color: byte[32], contract_id: byte[32]) -> uint64`
-    /// returns the current balance of `color` of contract with ID
-    /// `contract_id`.
-    ///
-    /// | Operation   | ```$rA = balance(MEM[$rB, 32], MEM[$rC, 32]);``` |
-    /// | Syntax      | `bal $rA, $rB, $rC`                              |
-    /// | Encoding    | `0x00 rA rB rC -`                                |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + 32` overflows
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - `$rC + 32` overflows
-    /// - `$rC + 32 > VM_MAX_RAM`
-    /// - Contract with ID `MEM[$rC, 32]` is not in `tx.inputs`
+    /// Get the balance of contract of an asset ID.
     BAL(RegisterId, RegisterId, RegisterId),
 
-    /// Get block header hash.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = blockhash($rB);``` |
-    /// | Syntax      | `bhsh $rA $rB`                       |
-    /// | Encoding    | `0x00 rA rB - -`                     |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    ///
-    /// Block header hashes for blocks with height greater than or equal to
-    /// current block height are zero (`0x00**32`).
+    /// Get block header hash for height.
     BHSH(RegisterId, RegisterId),
 
-    /// Get Fuel block height.
-    ///
-    /// | Operation   | ```$rA = blockheight();``` |
-    /// | Syntax      | `bhei $rA`                 |
-    /// | Encoding    | `0x00 rA - - -`            |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
+    /// Get current block height.
     BHEI(RegisterId),
 
-    /// Burn `$rA` coins of the current contract's color.
-    ///
-    /// | Operation   | ```burn($rA);```                                  |
-    /// | Syntax      | `burn $rA`                                        |
-    /// | Encoding    | `0x00 rA - - -`                                   |
-    ///
-    /// #### Panic
-    /// - Balance of color `MEM[$fp, 32]` of output with contract ID `MEM[$fp,
-    ///   32]` minus `$rA` underflows
-    /// - `$fp == 0` (in the script context)
-    ///
-    /// For output with contract ID `MEM[$fp, 32]`, decrease balance of color
-    /// `MEM[$fp, 32]` by `$rA`.
-    ///
-    /// This modifies the `balanceRoot` field of the appropriate output.
+    /// Burn coins of the current contract's asset ID.
     BURN(RegisterId),
 
-    /// Call contract.
-    ///
-    /// | Syntax      | `call $rA $rB $rC $rD` |
-    /// | Encoding    | `0x00 rA rB rC rD`     |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rC + 32` overflows
-    /// - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
-    /// - Reading past `MEM[VM_MAX_RAM - 1]`
-    /// - Any output range does not pass [ownership check](./main.md#ownership)
-    /// - In an external context, if `$rB > MEM[balanceOfStart(MEM[$rC, 32]),
-    ///   8]`
-    /// - In an internal context, if `$rB` is greater than the balance of color
-    ///   `MEM[$rC, 32]` of output with contract ID `MEM[$rA, 32]`
-    ///
-    /// Register `$rA` is a memory address from which the following fields are
-    /// set (word-aligned).
-    ///
-    /// `$rD` is the amount of gas to forward. If it is set to an amount greater
-    /// than the available gas, all available gas is forwarded.
-    ///
-    /// For output with contract ID `MEM[$rA, 32]`, increase balance of color
-    /// `MEM[$rC, 32]` by `$rB`. In an external context, decrease
-    /// `MEM[balanceOfStart(MEM[$rC, 32]), 8]` by `$rB`. In an internal context,
-    /// decrease color `MEM[$rC, 32]` balance of output with contract ID
-    /// `MEM[$fp, 32]` by `$rB`.
-    ///
-    /// A [call frame](./main.md#call-frames) is pushed at `$sp`. In addition to
-    /// filling in the values of the call frame, the following registers are
-    /// set:
-    ///
-    /// 1. `$fp = $sp` (on top of the previous call frame is the beginning of
-    /// this call frame) 1. Set `$ssp` and `$sp` to the start of the
-    /// writable stack area of the call frame. 1. Set `$pc` and `$is` to the
-    /// starting address of the code. 1. `$bal = $rD` (forward coins)
-    /// 1. `$cgas = $rD` or all available gas (forward gas)
-    ///
-    /// This modifies the `balanceRoot` field of the appropriate output(s).
+    /// Call a contract.
     CALL(RegisterId, RegisterId, RegisterId, RegisterId),
 
-    /// Copy `$rD` bytes of code starting at `$rC` for contract with ID equal to
-    /// the 32 bytes in memory starting at `$rB` into memory starting at `$rA`.
-    ///
-    /// | Operation   | ```MEM[$rA, $rD] = code($rB, $rC, $rD);```
-    /// | Syntax      | `ccp $rA, $rB, $rC, $rD`
-    /// | Encoding    | `0x00 rA rB rC rD`
-    /// | Notes       | If `$rD` is greater than the code size, zero bytes are
-    /// filled in.
-    ///
-    /// #### Panics
-    /// - `$rA + $rD` overflows
-    /// - `$rB + 32` overflows
-    /// - `$rA + $rD > VM_MAX_RAM`
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, $rD]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    /// - `$rD > MEM_MAX_ACCESS_SIZE`
-    /// - Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
+    /// Copy contract code for a contract.
     CCP(RegisterId, RegisterId, RegisterId, RegisterId),
 
-    /// Set the 32 bytes in memory starting at `$rA` to the code root for
-    /// contract with ID equal to the 32 bytes in memory starting at `$rB`.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = coderoot(MEM[$rB, 32]);```
-    /// | Syntax      | `croo $rA, $rB`
-    /// | Encoding    | `0x00 rA rB - -`
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rB + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    /// - Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
-    ///
-    /// Code root compuration is defined
-    /// [here](../protocol/identifiers.md#contract-id).
+    /// Get code root of a contract.
     CROO(RegisterId, RegisterId),
 
-    /// Set `$rA` to the size of the code for contract with ID equal to the 32
-    /// bytes in memory starting at `$rB`.
-    ///
-    /// | Operation   | ```$rA = codesize(MEM[$rB, 32]);```
-    /// | Syntax      | `csiz $rA, $rB`
-    /// | Encoding    | `0x00 rA rB - -`
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + 32` overflows
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - Contract with ID `MEM[$rB, 32]` is not in `tx.inputs`
+    /// Get code size of a contract.
     CSIZ(RegisterId, RegisterId),
 
-    /// Get block proposer address.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = coinbase();``` |
-    /// | Syntax      | `cb $rA`                         |
-    /// | Encoding    | `0x00 rA - - -`                  |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
+    /// Get current block proposer's address.
     CB(RegisterId),
 
-    /// Copy `$rC` bytes of code starting at `$rB` for contract with ID equal to
-    /// the 32 bytes in memory starting at `$rA` into memory starting at `$ssp`.
-    ///
-    /// | Operation   | ```MEM[$ssp, $rC] = code($rA, $rB, $rC);```
-    /// | Syntax      | `ldc $rA, $rB, $rC`
-    /// | Encoding    | `0x00 rA rB rC -`
-    /// | Notes       | If `$rC` is greater than the code size, zero bytes are
-    /// filled in.
-    ///
-    /// #### Panics
-    /// - `$ssp + $rC` overflows
-    /// - `$rA + 32` overflows
-    /// - `$ssp + $rC > VM_MAX_RAM`
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$ssp != $sp`
-    /// - `$ssp + $rC > $hp`
-    /// - `$rC > CONTRACT_MAX_SIZE`
-    /// - `$rC > MEM_MAX_ACCESS_SIZE`
-    /// - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
-    ///
-    /// Increment `$hp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word
-    /// alignment.
-    ///
-    /// This opcode can be used to concatenate the code of multiple contracts
-    /// together. It can only be used when the stack area of the call frame is
-    /// unused (i.e. prior to being used).
+    /// Load a contract's code as executable.
     LDC(RegisterId, RegisterId, RegisterId),
 
-    /// Log an event. This is a no-op.
-    ///
-    /// | Operation   | ```log($rA, $rB, $rC, $rD);``` |
-    /// | Syntax      | `log $rA, $rB, $rC, $rD`       |
-    /// | Encoding    | `0x00 rA rB rC rD`             |
+    /// Log an event.
     LOG(RegisterId, RegisterId, RegisterId, RegisterId),
 
-    /// Logs the memory range `MEM[$rC, $rD]`. This is a no-op.
-    ///
-    /// | Syntax      | `logd $rA, $rB, $rC, $rD`       |
-    /// | Encoding    | `0x00 rA rB rC rD`              |
+    /// Log data.
     LOGD(RegisterId, RegisterId, RegisterId, RegisterId),
 
-    /// Mint `$rA` coins of the current contract's color.
-    ///
-    /// | Operation   | ```mint($rA);```                                  |
-    /// | Syntax      | `mint $rA`                                        |
-    /// | Encoding    | `0x00 rA - - -`                                   |
-    ///
-    /// #### Panics
-    /// - Balance of color `MEM[$fp, 32]` of output with contract ID `MEM[$fp,
-    ///   32]` plus `$rA` overflows
-    /// - `$fp == 0` (in the script context)
-    ///
-    /// For output with contract ID `MEM[$fp, 32]`, increase balance of color
-    /// `MEM[$fp, 32]` by `$rA`.
-    ///
-    /// This modifies the `balanceRoot` field of the appropriate output.
+    /// Mint coins of the current contract's asset ID.
     MINT(RegisterId),
 
-    /// Halt execution, reverting state changes and returning value in `$rA`.
-    ///
-    /// | Operation   | ```revert($rA);```
-    /// | Syntax      | `rvrt $rA`
-    /// | Encoding    | `0x00 rA - - -`
-    ///
-    /// After a revert:
-    ///
-    /// 1. All [OutputContract](../protocol/tx_format.md#outputcontract) outputs
-    /// will have the same `amount` and `stateRoot` as on initialization. 1.
-    /// All OutputVariable (../protocol/tx_format.md outputs#outputvariable)
-    /// outputs will have `to` and `amount` of zero.
-    /// 1. All OutputContractConditional (../protocol/tx_format.md#
-    /// outputcontractconditional) outputs will have `contractID`, `amount`, and
-    /// `stateRoot` of zero.
+    /// Halt execution, reverting state changes and returning a value.
     RVRT(RegisterId),
 
-    /// Copy `$rC` bytes of code starting at `$rB` for contract with static
-    /// index `$rA` into memory starting at `$ssp`.
-    ///
-    /// | Operation   | ```MEM[$ssp, $rC] = scode($rA, $rB, $rC);```
-    /// | Syntax      | `sloadcode $rA, $rB, $rC`
-    /// | Encoding    | `0x00 rA rB rC -`
-    /// | Notes       | If `$rC` is greater than the code size, zero bytes
-    /// are filled in.                                               |
-    ///
-    /// #### Panics
-    /// - `$ssp + $rC` overflows
-    /// - `$ssp + $rC > VM_MAX_RAM`
-    /// - `$rA >= MAX_STATIC_CONTRACTS`
-    /// - `$rA` is greater than or equal to `staticContractsCount` for the
-    ///   contract with ID `MEM[$fp, 32]`
-    /// - `$ssp != $sp`
-    /// - `$ssp + $rC > $hp`
-    /// - `$rC > CONTRACT_MAX_SIZE`
-    /// - `$rC > MEM_MAX_ACCESS_SIZE`
-    /// - `$fp == 0` (in the script context)
-    ///
-    /// Increment `$hp->codesize`, `$ssp`, and `$sp` by `$rC` padded to word
-    /// alignment.
-    ///
-    /// This opcode can be used to concatenate the code of multiple contracts
-    /// together. It can only be used when the stack area of the call frame is
-    /// unused (i.e. prior to being used).
+    /// Load a static contract's code as executable.
     SLDC(RegisterId, RegisterId, RegisterId),
 
-    /// A word is read from the current contract's state.
-    ///
-    /// | Operation   | ```$rA = STATE[MEM[$rB, 32]][0, 8];```            |
-    /// | Syntax      | `srw $rA, $rB`                                    |
-    /// | Encoding    | `0x00 rA rB - -`                                  |
-    /// | Notes       | Returns zero if the state element does not exist. |
-    ///
-    /// #### Panics
-    /// - `$rA` is a [reserved register](./main.md#semantics)
-    /// - `$rB + 32` overflows
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - `$fp == 0` (in the script context)
+    /// Load a word from contract storage.
     SRW(RegisterId, RegisterId),
 
-    /// 32 bytes is read from the current contract's state.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = STATE[MEM[$rB, 32]];```           |
-    /// | Syntax      | `srwx $rA, $rB`                                     |
-    /// | Encoding    | `0x00 rA rB - -`                                    |
-    /// | Notes       | Returns zero if the state element does not exist.   |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rB + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    /// - `$fp == 0` (in the script context)
+    /// Load 32 bytes from contract storage.
     SRWQ(RegisterId, RegisterId),
 
-    /// A word is written to the current contract's state.
-    ///
-    /// | Operation   | ```STATE[MEM[$rA, 32]][0, 8] = $rB;```             |
-    /// | Syntax      | `sww $rA $rB`                                      |
-    /// | Encoding    | `0x00 rA rB - -`                                   |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$fp == 0` (in the script context)
+    /// Store a word in contract storage.
     SWW(RegisterId, RegisterId),
 
-    /// 32 bytes is written to the current contract's state.
-    ///
-    /// | Operation   | ```STATE[MEM[$rA, 32]] = MEM[$rB, 32];```            |
-    /// | Syntax      | `swwx $rA, $rB`                                      |
-    /// | Encoding    | `0x00 rA rB - -`                                     |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rB + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rB + 32 > VM_MAX_RAM`
-    /// - `$fp == 0` (in the script context)
+    /// Store 32 bytes in contract storage.
     SWWQ(RegisterId, RegisterId),
 
-    /// Transfer `$rB` coins with color at `$rC` to contract with ID at `$rA`.
-    ///
-    /// | Operation   | ```transfer(MEM[$rA, 32], $rB, MEM[$rC, 32]);```
-    /// | Syntax      | `tr $rA,  $rB, $rC`
-    /// | Encoding    | `0x00 rA rB rC -`
-    ///
-    /// Given helper `balanceOfStart(color: byte[32]) -> uint32` which returns
-    /// the memory address of `color` balance, or `0` if `color` has no balance.
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rC + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rC + 32 > VM_MAX_RAM`
-    /// - Contract with ID `MEM[$rA, 32]` is not in `tx.inputs`
-    /// - In an external context, if `$rB > MEM[balanceOf(MEM[$rC, 32]), 8]`
-    /// - In an internal context, if `$rB` is greater than the balance of color
-    ///   `MEM[$rC, 32]` of output with contract ID `MEM[$fp, 32]`
-    /// - `$rB == 0`
-    ///
-    /// For output with contract ID `MEM[$rA, 32]`, increase balance of color
-    /// `MEM[$rC, 32]` by `$rB`. In an external context, decrease
-    /// `MEM[balanceOfStart(MEM[$rC, 32]), 8]` by `$rB`. In an internal context,
-    /// decrease color `MEM[$rC, 32]` balance of output with contract ID
-    /// `MEM[$fp, 32]` by `$rB`.
-    ///
-    /// This modifies the `balanceRoot` field of the appropriate output(s).
+    /// Transfer coins to a contract unconditionally.
     TR(RegisterId, RegisterId, RegisterId),
 
-    /// Transfer `$rC` coins with color at `$rD` to address at `$rA`, with
-    /// output `$rB`. | Operation   | ```transferout(MEM[$rA, 32], $rB, $rC,
-    /// MEM[$rD, 32]);``` | Syntax      | `tro $rA, $rB, $rC, $rD`
-    /// | Encoding    | `0x00 rA rB rC rD`
-    ///
-    /// Given helper `balanceOfStart(color: byte[32]) -> uint32` which returns
-    /// the memory address of `color` balance, or `0` if `color` has no balance.
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rD + 32` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rD + 32 > VM_MAX_RAM`
-    /// - `$rB > tx.outputsCount`
-    /// - In an external context, if `$rC > MEM[balanceOf(MEM[$rD, 32]), 8]`
-    /// - In an internal context, if `$rC` is greater than the balance of color
-    ///   `MEM[$rD, 32]` of output with contract ID `MEM[$fp, 32]`
-    /// - `$rC == 0`
-    /// - `tx.outputs[$rB].type != OutputType.Variable`
-    /// - `tx.outputs[$rB].amount != 0`
-    ///
-    /// In an external context, decrease `MEM[balanceOfStart(MEM[$rD, 32]), 8]`
-    /// by `$rC`. In an internal context, decrease color `MEM[$rD, 32]` balance
-    /// of output with contract ID `MEM[$fp, 32]` by `$rC`. Then set:
-    ///
-    /// - `tx.outputs[$rB].to = MEM[$rA, 32]`
-    /// - `tx.outputs[$rB].amount = $rC`
-    /// - `tx.outputs[$rB].color = MEM[$rD, 32]`
-    ///
-    /// This modifies the `balanceRoot` field of the appropriate output(s).
+    /// Transfer coins to a variable output.
     TRO(RegisterId, RegisterId, RegisterId, RegisterId),
 
     /// The 64-byte public key (x, y) recovered from 64-byte
-    /// signature starting at `$rB` on 32-byte message hash starting at `$rC`. |
-    ///
-    /// | Operation   | ```MEM[$rA, 64] = ecrecover(MEM[$rB, 64], MEM[$rC,
-    /// 32]);``` | Syntax      | `ecr $rA, $rB, $rC`
-    /// | Encoding    | `0x00 rA rB rC -`
-    ///
-    /// #### Panics
-    /// - `$rA + 64` overflows
-    /// - `$rB + 64` overflows
-    /// - `$rC + 32` overflows
-    /// - `$rA + 64 > VM_MAX_RAM`
-    /// - `$rB + 64 > VM_MAX_RAM`
-    /// - `$rC + 32 > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 64]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    ///
-    /// To get the address, hash the public key with
-    /// [SHA-2-256](#sha256-sha-2-256).
+    /// signature on 32-byte message.
     ECR(RegisterId, RegisterId, RegisterId),
 
-    /// The keccak-256 hash of `$rC` bytes starting at `$rB`.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = keccak256(MEM[$rB, $rC]);```
-    /// | Syntax      | `k256 $rA, $rB, $rC`
-    /// | Encoding    | `0x00 rA rB rC -`
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rB + $rC` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rB + $rC > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    /// - `$rC > MEM_MAX_ACCESS_SIZE`
+    /// The keccak-256 hash of a slice.
     K256(RegisterId, RegisterId, RegisterId),
 
-    /// The SHA-2-256 hash of `$rC` bytes starting at `$rB`.
-    ///
-    /// | Operation   | ```MEM[$rA, 32] = sha256(MEM[$rB, $rC]);```          |
-    /// | Syntax      | `s256 $rA, $rB, $rC`                                 |
-    /// | Encoding    | `0x00 rA rB rC -`                                    |
-    ///
-    /// #### Panics
-    /// - `$rA + 32` overflows
-    /// - `$rB + $rC` overflows
-    /// - `$rA + 32 > VM_MAX_RAM`
-    /// - `$rB + $rC > VM_MAX_RAM`
-    /// - The memory range `MEM[$rA, 32]`  does not pass [ownership
-    ///   check](./main.md#ownership)
-    /// - `$rC > MEM_MAX_ACCESS_SIZE`
+    /// The SHA-2-256 hash of a slice.
     S256(RegisterId, RegisterId, RegisterId),
 
-    /// Set `$rA` to the length in bytes of [the `$rB`th
-    /// input](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xil($rB);```      |
-    /// | Syntax      | `xil $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.inputsCount`
+    /// Get the length in bytes of an input.
     XIL(RegisterId, RegisterId),
 
-    /// Set `$rA` to the memory addess of the start of [the `$rB`th
-    /// input](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xis($rB);```      |
-    /// | Syntax      | `xis $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.inputsCount`
+    /// Get the memory addess of the start of an input.
     XIS(RegisterId, RegisterId),
 
-    /// Set `$rA` to the length in bytes of [the `$rB`th
-    /// output](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xol($rB);```      |
-    /// | Syntax      | `xol $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.outputsCount`
+    /// Get the length in bytes of an output.
     XOL(RegisterId, RegisterId),
 
-    /// Set `$rA` to the memory addess of the start of [the `$rB`th
-    /// output](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xos($rB);```      |
-    /// | Syntax      | `xos $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.outputsCount`
+    /// Get the memory addess of the start of an output.
     XOS(RegisterId, RegisterId),
 
-    /// Set `$rA` to the length in bytes of [the `$rB`th
-    /// witness](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xwl($rB);```      |
-    /// | Syntax      | `xwl $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.witnessesCount`
-    ///
-    /// Note that the returned length includes the [_entire_
-    /// witness](../protocol/tx_format.md), not just of the witness's `data`
-    /// field.
+    /// Get the length in bytes of a witness.
     XWL(RegisterId, RegisterId),
 
-    /// Set `$rA` to the memory addess of the start of [the `$rB`th
-    /// witness](./main.md#vm-initialization).
-    ///
-    /// | Operation   | ```$rA = xws($rB);```      |
-    /// | Syntax      | `xws $rA, $rB`             |
-    /// | Encoding    | `0x00 rA rB - -`           |
-    ///
-    /// #### Panics
-    /// - `$rB >= tx.witnessesCount`
-    ///
-    /// Note that the returned memory address includes the [_entire_
-    /// witness](../protocol/tx_format.md), not just of the witness's `data`
-    /// field.
+    /// Get the memory addess of the start of a witness.
     XWS(RegisterId, RegisterId),
 
     /// Performs no operation.
-    ///
-    /// | Operation   |                        |
-    /// | Syntax      | `noop`                 |
-    /// | Encoding    | `0x00 - - - -`         |
-    ///
-    /// `$of` and `$err` are cleared.
     NOOP,
 
-    /// Set `$flag` to `$rA`.
-    ///
-    /// | Operation   | ```$flag = $rA;```    |
-    /// | Syntax      | `flag $rA`            |
-    /// | Encoding    | `0x00 rA - - -`       |
+    /// Set flag register to a register.
     FLAG(RegisterId),
 
-    /// Get metadata from memory
-    ///
-    /// | Operation   | Selected by `imm`     |
-    /// | Syntax      | `gm $rA, imm`         |
-    /// | Encoding    | `0x00 rA imm imm imm` |
+    /// Get metadata from memory.
     GM(RegisterId, Immediate18),
 
-    /// Undefined opcode, potentially from inconsistent serialization
+    /// Undefined opcode, potentially from inconsistent serialization.
     Undefined,
 }
 


### PR DESCRIPTION
Long documentation wasn't maintained, so removed in favor of simple strings.