### PR TITLE
Bounds Checked Immediate Values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ path = "tests/encoding.rs"
 required-features = ["std"]
 
 [patch.crates-io]
-fuel-types = { path = "./../fuel-types" }
+fuel-types = { git = "https://github.com/FuelLabs/fuel-types", branch = "checked-imms" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ serde-types-minimal = ["fuel-types/serde-types-minimal", "serde"]
 name = "test-encoding"
 path = "tests/encoding.rs"
 required-features = ["std"]
+
+[patch.crates-io]
+fuel-types = { path = "./../fuel-types" }

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ use Opcode::*;
 // A sample program to perform ecrecover
 let program = vec![
     MOVE(0x10, 0x01),      // set r[0x10] := $one
-    SLLI(0x20, 0x10, 5),   // set r[0x20] := `r[0x10] << 5 == 32`
-    SLLI(0x21, 0x10, 6),   // set r[0x21] := `r[0x10] << 6 == 64`
+    SLLI(0x20, 0x10, Immediate12::new(5).unwrap()),   // set r[0x20] := `r[0x10] << 5 == 32`
+    SLLI(0x21, 0x10, Immediate12::new(6).unwrap()),   // set r[0x21] := `r[0x10] << 6 == 64`
     ALOC(0x21),            // alloc `r[0x21] == 64` to the heap
-    ADDI(0x10, 0x07, 1),   // set r[0x10] := `$hp + 1` (allocated heap)
+    ADDI(0x10, 0x07, Immediate12::new(1).unwrap()),   // set r[0x10] := `$hp + 1` (allocated heap)
     MOVE(0x11, 0x04),      // set r[0x11] := $ssp
     ADD(0x12, 0x04, 0x20), // set r[0x12] := `$ssp + r[0x20]`
     ECR(0x10, 0x11, 0x12), // recover public key in memory[r[0x10], 64]

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -48,10 +48,22 @@ impl Instruction {
         let rc = ((instruction >> 6) & 0x3f) as RegisterId;
         let rd = (instruction & 0x3f) as RegisterId;
 
-        let imm06 = (instruction & 0xff) as Immediate06;
-        let imm12 = (instruction & 0x0fff) as Immediate12;
-        let imm18 = (instruction & 0x3ffff) as Immediate18;
-        let imm24 = (instruction & 0xffffff) as Immediate24;
+        let imm06 = match Immediate06::new((instruction & 0x3F) as u8) {
+            Some(v) => v,
+            None => panic!("out of bounds"),
+        };
+        let imm12 = match Immediate12::new((instruction & 0x0fff) as u16) {
+            Some(v) => v,
+            None => panic!("out of bounds"),
+        };
+        let imm18 = match Immediate18::new(instruction & 0x3ffff) {
+            Some(v) => v,
+            None => panic!("out of bounds"),
+        };
+        let imm24 = match Immediate24::new(instruction & 0xffffff) {
+            Some(v) => v,
+            None => panic!("out of bounds"),
+        };
 
         Self {
             op,
@@ -168,9 +180,9 @@ impl Instruction {
         let repr = OpcodeRepr::from_u8(op);
 
         let _ = imm06;
-        let imm12 = imm12 as Word;
-        let imm18 = imm18 as Word;
-        let imm24 = imm24 as Word;
+        let imm12 = imm12.get() as Word;
+        let imm18 = imm18.get() as Word;
+        let imm24 = imm24.get() as Word;
 
         let imm12_mask = (op & 0xf0 == 0x50) || (op & 0xf0 == 0x60);
         let imm18_mask = (op & 0xf0 == 0x70) || (op & 0xf0 == 0x80);
@@ -214,9 +226,9 @@ impl From<Instruction> for u32 {
         let c = (parsed.rc as u32) << 6;
         let d = parsed.rd as u32;
 
-        let imm12 = parsed.imm12 as u32;
-        let imm18 = parsed.imm18 as u32;
-        let imm24 = parsed.imm24 as u32;
+        let imm12 = parsed.imm12.get() as u32;
+        let imm18 = parsed.imm18.get() as u32;
+        let imm24 = parsed.imm24.get() as u32;
 
         let repr = OpcodeRepr::from_u8(parsed.op);
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -516,11 +516,11 @@ impl Opcode {
             | Self::LB(_, _, imm)
             | Self::LW(_, _, imm)
             | Self::SB(_, _, imm)
-            | Self::SW(_, _, imm) => Some(*imm as Word),
+            | Self::SW(_, _, imm) => Some(imm.get() as Word),
 
-            Self::MCLI(_, imm) | Self::GM(_, imm) => Some(*imm as Word),
+            Self::MCLI(_, imm) | Self::GM(_, imm) => Some(imm.get() as Word),
 
-            Self::JI(imm) | Self::CFEI(imm) | Self::CFSI(imm) => Some(*imm as Word),
+            Self::JI(imm) | Self::CFEI(imm) | Self::CFSI(imm) => Some(imm.get() as Word),
 
             Self::ADD(_, _, _)
             | Self::AND(_, _, _)
@@ -668,7 +668,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::ADDI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::AND(ra, rb, rc) => {
                 ((OpcodeRepr::AND as u32) << 24)
@@ -680,7 +680,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::ANDI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::DIV(ra, rb, rc) => {
                 ((OpcodeRepr::DIV as u32) << 24)
@@ -692,7 +692,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::DIVI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::EQ(ra, rb, rc) => {
                 ((OpcodeRepr::EQ as u32) << 24)
@@ -710,7 +710,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::EXPI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::GT(ra, rb, rc) => {
                 ((OpcodeRepr::GT as u32) << 24)
@@ -746,7 +746,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::MODI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::MOVE(ra, rb) => {
                 ((OpcodeRepr::MOVE as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
@@ -761,7 +761,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::MULI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::NOT(ra, rb) => {
                 ((OpcodeRepr::NOT as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
@@ -776,7 +776,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::ORI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::SLL(ra, rb, rc) => {
                 ((OpcodeRepr::SLL as u32) << 24)
@@ -788,7 +788,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::SLLI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::SRL(ra, rb, rc) => {
                 ((OpcodeRepr::SRL as u32) << 24)
@@ -800,7 +800,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::SRLI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::SUB(ra, rb, rc) => {
                 ((OpcodeRepr::SUB as u32) << 24)
@@ -812,7 +812,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::SUBI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::XOR(ra, rb, rc) => {
                 ((OpcodeRepr::XOR as u32) << 24)
@@ -824,7 +824,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::XORI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::CIMV(ra, rb, rc) => {
                 ((OpcodeRepr::CIMV as u32) << 24)
@@ -835,37 +835,37 @@ impl From<Opcode> for u32 {
             Opcode::CTMV(ra, rb) => {
                 ((OpcodeRepr::CTMV as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
             }
-            Opcode::JI(imm24) => ((OpcodeRepr::JI as u32) << 24) | (imm24 as u32),
+            Opcode::JI(imm24) => ((OpcodeRepr::JI as u32) << 24) | (imm24.get() as u32),
             Opcode::JNEI(ra, rb, imm12) => {
                 ((OpcodeRepr::JNEI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::RET(ra) => ((OpcodeRepr::RET as u32) << 24) | ((ra as u32) << 18),
             Opcode::RETD(ra, rb) => {
                 ((OpcodeRepr::RETD as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
             }
-            Opcode::CFEI(imm24) => ((OpcodeRepr::CFEI as u32) << 24) | (imm24 as u32),
-            Opcode::CFSI(imm24) => ((OpcodeRepr::CFSI as u32) << 24) | (imm24 as u32),
+            Opcode::CFEI(imm24) => ((OpcodeRepr::CFEI as u32) << 24) | (imm24.get() as u32),
+            Opcode::CFSI(imm24) => ((OpcodeRepr::CFSI as u32) << 24) | (imm24.get() as u32),
             Opcode::LB(ra, rb, imm12) => {
                 ((OpcodeRepr::LB as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::LW(ra, rb, imm12) => {
                 ((OpcodeRepr::LW as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::ALOC(ra) => ((OpcodeRepr::ALOC as u32) << 24) | ((ra as u32) << 18),
             Opcode::MCL(ra, rb) => {
                 ((OpcodeRepr::MCL as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
             }
             Opcode::MCLI(ra, imm18) => {
-                ((OpcodeRepr::MCLI as u32) << 24) | ((ra as u32) << 18) | (imm18 as u32)
+                ((OpcodeRepr::MCLI as u32) << 24) | ((ra as u32) << 18) | (imm18.get() as u32)
             }
             Opcode::MCP(ra, rb, rc) => {
                 ((OpcodeRepr::MCP as u32) << 24)
@@ -877,7 +877,7 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::MCPI as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::MEQ(ra, rb, rc, rd) => {
                 ((OpcodeRepr::MEQ as u32) << 24)
@@ -890,13 +890,13 @@ impl From<Opcode> for u32 {
                 ((OpcodeRepr::SB as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::SW(ra, rb, imm12) => {
                 ((OpcodeRepr::SW as u32) << 24)
                     | ((ra as u32) << 18)
                     | ((rb as u32) << 12)
-                    | (imm12 as u32)
+                    | (imm12.get() as u32)
             }
             Opcode::BAL(ra, rb, rc) => {
                 ((OpcodeRepr::BAL as u32) << 24)
@@ -1022,7 +1022,7 @@ impl From<Opcode> for u32 {
             Opcode::NOOP => (OpcodeRepr::NOOP as u32) << 24,
             Opcode::FLAG(ra) => ((OpcodeRepr::FLAG as u32) << 24) | ((ra as u32) << 18),
             Opcode::GM(ra, imm18) => {
-                ((OpcodeRepr::GM as u32) << 24) | ((ra as u32) << 18) | (imm18 as u32)
+                ((OpcodeRepr::GM as u32) << 24) | ((ra as u32) << 18) | (imm18.get() as u32)
             }
             Opcode::Undefined => (0x00 << 24),
         }

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -5,9 +5,9 @@ use std::io::{Read, Write};
 fn opcode() {
     // TODO maybe split this test case into several smaller ones?
     let r = 0x3f;
-    let imm12 = 0xbff;
-    let imm18 = 0x2ffff;
-    let imm24 = 0xbfffff;
+    let imm12 = Immediate12::new(0xbffu16).unwrap();
+    let imm18 = Immediate18::new(0x2ffffu32).unwrap();
+    let imm24 = Immediate24::new(0xbfffffu32).unwrap();
 
     let mut data = vec![
         Opcode::ADD(r, r, r),
@@ -192,7 +192,7 @@ fn opcode() {
 
 #[test]
 fn panic_reason_description() {
-    let imm24 = 0xbfffff;
+    let imm24 = Immediate24::new(0xbfffff).unwrap();
 
     let reasons = vec![
         PanicReason::Revert,


### PR DESCRIPTION
Using the opcode types directly can lead to unpredictable behavior due to precision loss when handling immediate value types. This PR introduces new immediate types that can enforce the integrity of the immediate values and help avoid silent precision losses.