### PR TITLE
Add MOVI opcode

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -293,7 +293,7 @@ impl From<Instruction> for u32 {
 
             OpcodeRepr::JI | OpcodeRepr::CFEI | OpcodeRepr::CFSI => imm24,
 
-            OpcodeRepr::MCLI | OpcodeRepr::GM => a | imm18,
+            OpcodeRepr::MCLI | OpcodeRepr::GM | OpcodeRepr::MOVI => a | imm18,
 
             OpcodeRepr::MEQ
             | OpcodeRepr::CALL

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -91,6 +91,9 @@ pub enum Opcode {
     /// Copy from one register to another.
     MOVE(RegisterId, RegisterId),
 
+    /// Copy immediate value into a register
+    MOVI(RegisterId, Immediate18),
+
     /// Multiplies two registers.
     MUL(RegisterId, RegisterId, RegisterId),
 
@@ -322,6 +325,7 @@ impl Opcode {
             OpcodeRepr::MOD => Opcode::MOD(ra, rb, rc),
             OpcodeRepr::MODI => Opcode::MODI(ra, rb, imm12),
             OpcodeRepr::MOVE => Opcode::MOVE(ra, rb),
+            OpcodeRepr::MOVI => Opcode::MOVI(ra, imm18),
             OpcodeRepr::MUL => Opcode::MUL(ra, rb, rc),
             OpcodeRepr::MULI => Opcode::MULI(ra, rb, imm12),
             OpcodeRepr::NOT => Opcode::NOT(ra, rb),
@@ -429,6 +433,7 @@ impl Opcode {
             Self::MOD(ra, rb, rc) => [Some(*ra), Some(*rb), Some(*rc), None],
             Self::MODI(ra, rb, _) => [Some(*ra), Some(*rb), None, None],
             Self::MOVE(ra, rb) => [Some(*ra), Some(*rb), None, None],
+            Self::MOVI(ra, _) => [Some(*ra), None, None, None],
             Self::MUL(ra, rb, rc) => [Some(*ra), Some(*rb), Some(*rc), None],
             Self::MULI(ra, rb, _) => [Some(*ra), Some(*rb), None, None],
             Self::NOT(ra, rb) => [Some(*ra), Some(*rb), None, None],
@@ -518,7 +523,7 @@ impl Opcode {
             | Self::SB(_, _, imm)
             | Self::SW(_, _, imm) => Some(*imm as Word),
 
-            Self::MCLI(_, imm) | Self::GM(_, imm) => Some(*imm as Word),
+            Self::MCLI(_, imm) | Self::GM(_, imm) | Self::MOVI(_, imm) => Some(*imm as Word),
 
             Self::JI(imm) | Self::CFEI(imm) | Self::CFSI(imm) => Some(*imm as Word),
 
@@ -750,6 +755,9 @@ impl From<Opcode> for u32 {
             }
             Opcode::MOVE(ra, rb) => {
                 ((OpcodeRepr::MOVE as u32) << 24) | ((ra as u32) << 18) | ((rb as u32) << 12)
+            }
+            Opcode::MOVI(ra, imm18) => {
+                ((OpcodeRepr::MOVI as u32) << 24) | ((ra as u32) << 18) | (imm18 as u32)
             }
             Opcode::MUL(ra, rb, rc) => {
                 ((OpcodeRepr::MUL as u32) << 24)

--- a/src/opcode/consts.rs
+++ b/src/opcode/consts.rs
@@ -237,8 +237,8 @@ pub enum OpcodeRepr {
     MCLI = 0x70,
     /// GM
     GM = 0x71,
-    /// RESERV72
-    RESERV72 = 0x72,
+    /// MOVI
+    MOVI = 0x72,
     /// RESERV73
     RESERV73 = 0x73,
     /// RESERV74

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -26,6 +26,7 @@ fn opcode() {
         Opcode::MOD(r, r, r),
         Opcode::MODI(r, r, imm12),
         Opcode::MOVE(r, r),
+        Opcode::MOVI(r, imm18),
         Opcode::MUL(r, r, r),
         Opcode::MULI(r, r, imm12),
         Opcode::NOT(r, r),


### PR DESCRIPTION
Adds the definition of the `movi ra imm18` opcode define in the specs: https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/opcodes.md#movi-move-immediate

This will replace usages of addi when trying to set a register to some value in scripts, since addi is limited to imm12 which isn't large enough to handle transactions with 255 inputs when configuring a script data offset.