### PR TITLE
add rust caching and speed up tag validation on publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Rust Caching
+      uses: Swatinem/rust-cache@v1
+
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -115,8 +118,10 @@ jobs:
 
       - name: Verify tag version
         run: |
-          cargo install toml-cli
+          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} Cargo.toml
+
       - name: Publish crate
         uses: katyo/publish-crates@v1
         with:

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -25,7 +25,7 @@ fi
 
 # strip preceeding 'v' if it exists on tag
 REF=${REF/#v}
-TOML_VERSION=$(toml get $MANIFEST package.version | tr -d '"')
+TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
 
 if [ "$TOML_VERSION" != "$REF" ]; then
     err "Crate version $TOML_VERSION, doesn't match tag version $REF"


### PR DESCRIPTION
Use dasel for tag validation like some of our other repos and also enable the github rust caching CI action.