### PR TITLE
Re-export deps used in public interfaces + docs improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,11 @@ serde-types-minimal = ["fuel-types/serde-types-minimal", "serde"]
 name = "test-encoding"
 path = "tests/encoding.rs"
 required-features = ["std"]
+
+# docs.rs-specific configuration
+# preview with `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open`
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,6 @@ pub use fuel_types::{self, Immediate06, Immediate12, Immediate18, Immediate24, R
 pub use instruction::Instruction;
 pub use opcode::{Opcode, OpcodeRepr};
 pub use panic_reason::{InstructionResult, PanicReason};
+#[cfg(feature = "serde-types-minimal")]
+#[doc(no_inline)]
+pub use serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! FuelVM opcodes representation
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", doc = include_str!("../README.md"))]
 #![warn(missing_docs)]
@@ -10,7 +11,8 @@ mod panic_reason;
 
 mod macros;
 
-pub use fuel_types::{Immediate06, Immediate12, Immediate18, Immediate24, RegisterId, Word};
+#[doc(no_inline)]
+pub use fuel_types::{self, Immediate06, Immediate12, Immediate18, Immediate24, RegisterId, Word};
 pub use instruction::Instruction;
 pub use opcode::{Opcode, OpcodeRepr};
 pub use panic_reason::{InstructionResult, PanicReason};


### PR DESCRIPTION
Re-export any crate dependencies that provide types used in the public interfaces of this crate. This will help cut down on the number of version bumps required downstream in the future.

Also enhance docs using nightly features on docs.rs (similar to https://github.com/FuelLabs/fuel-crypto/pull/21)