### PR TITLE
Add `non-exhaustive` to exhaustive enums

### DIFF
--- a/src/opcode/consts.rs
+++ b/src/opcode/consts.rs
@@ -2,6 +2,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum OpcodeRepr {
     /// RESERV00
     RESERV00 = 0x00,

--- a/src/panic_reason.rs
+++ b/src/panic_reason.rs
@@ -7,6 +7,7 @@ const WORD_SIZE: usize = mem::size_of::<Word>();
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
+#[non_exhaustive]
 /// Panic reason representation for the interpreter.
 pub enum PanicReason {
     /// Representation reserved per protocol.


### PR DESCRIPTION
Some enums use an exhaustive variants count to allow no-op bytes
conversion.

However, this might be inconvenient when allocating these reserved
variants into concrete logical ones because it would mean a breaking
change.

The expected usage of these enums is to never have exhaustive match
blocks so replaced reserved variants will never break downstream. To do
that, we need the `non-exhaustive` directive enabled for these enums so
the consumers can safely match only the concrete logical variants.