### PR TITLE
bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-asm"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "data-structures", "parsing"]
 edition = "2021"


### PR DESCRIPTION
bump to 0.9.0
since we have a breaking change in removing reference to InputOwner