### PR TITLE
Add `From<PanicReason>` for io::Error

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1018,7 +1018,7 @@ impl From<Opcode> for u32 {
                     | ((rb as u32) << 12)
                     | (imm12 as u32)
             }
-            Opcode::Undefined => (0x00 << 24),
+            Opcode::Undefined => 0x00 << 24,
         }
     }
 }

--- a/src/panic_reason.rs
+++ b/src/panic_reason.rs
@@ -639,3 +639,12 @@ impl From<InstructionResult> for PanicReason {
         r.reason
     }
 }
+
+#[cfg(feature = "std")]
+impl From<PanicReason> for std::io::Error {
+    fn from(reason: PanicReason) -> Self {
+        use std::io;
+
+        io::Error::new(io::ErrorKind::Other, reason)
+    }
+}


### PR DESCRIPTION
We often need to convert directly from a panic reason to an io error, such as when performing to/from bytes encoding - in that case, the VM will not be intermediary to the operation and the conversion will be performed directly.

This commit introduces a transparent conversion between the error types.